### PR TITLE
feat(network): allows custom resource limits for cloud networks

### DIFF
--- a/rapyuta_io/clients/common_models.py
+++ b/rapyuta_io/clients/common_models.py
@@ -1,5 +1,8 @@
 import rapyuta_io
 from rapyuta_io.utils.object_converter import ObjBase, enum_field
+import six
+from rapyuta_io.utils.error import InvalidParameterException
+from rapyuta_io.utils import ObjDict
 
 
 class InternalDeploymentStatus(ObjBase):
@@ -20,6 +23,7 @@ class InternalDeploymentStatus(ObjBase):
     :param error_code: error code of the internal deployment
     :type error_code: list(str)
     """
+
     def __init__(self, phase, status=None, error_code=None):
         self.phase = phase
         self.status = status
@@ -34,3 +38,44 @@ class InternalDeploymentStatus(ObjBase):
 
     def get_serialize_map(self):
         return {}
+
+
+class Limits(ObjDict, ObjBase):
+    """
+    Limits represent the cpu and memory specs of a cloud network
+
+    :ivar cpu: cpu
+    :vartype cpu: Union [float, integer]
+    :ivar memory: memory
+    :vartype memory: integer
+
+    :param cpu: cpu
+    :type cpu: Union [float, integer]
+    :param memory: memory
+    :type memory: integer
+    """
+
+    def __init__(self, cpu, memory):
+        self.validate(cpu, memory)
+        super(ObjDict, self).__init__(cpu=cpu, memory=memory)
+
+    @staticmethod
+    def validate(cpu, memory):
+        if not isinstance(cpu, float) and not isinstance(cpu, six.integer_types):
+            raise InvalidParameterException('cpu must be a float or integer')
+        if cpu <= 0:
+            raise InvalidParameterException('cpu must be a positive number')
+        if not isinstance(memory, six.integer_types) or memory <= 0:
+            raise InvalidParameterException('memory must be a positive integer')
+
+    def get_deserialize_map(self):
+        return {
+            'cpu': 'cpu',
+            'memory': 'memory',
+        }
+
+    def get_serialize_map(self):
+        return {
+            'cpu': 'cpu',
+            'memory': 'memory',
+        }

--- a/rapyuta_io/clients/routed_network.py
+++ b/rapyuta_io/clients/routed_network.py
@@ -10,7 +10,7 @@ from rapyuta_io.utils.rest_client import HttpMethod
 from rapyuta_io.utils.utils import create_auth_header, get_api_response_data
 from rapyuta_io.utils.error import InvalidParameterException
 from rapyuta_io.utils.partials import PartialMixin
-
+from rapyuta_io.clients.common_models import Limits
 
 class RoutedNetwork(PartialMixin, ObjDict):
     """
@@ -147,51 +147,7 @@ class Parameters(ObjDict):
     :type limits: :py:class:`~rapyuta_io.clients.routed_network.RoutedNetworkLimits`
     """
 
-    def __init__(self, limits):
-        self.validate(limits)
+    def __init__(self, limits = None):
         super(ObjDict, self).__init__(limits=limits)
 
-    @staticmethod
-    def validate(limits):
-        if not isinstance(limits, _Limits):
-            raise InvalidParameterException('limits must be one of '
-                                            'rapyuta_io.clients.routed_network.RoutedNetworkLimits')
 
-
-class _Limits(ObjDict):
-    """
-    Limits represents cpu, memory details of the parameter
-
-    :ivar cpu: cpu
-    :vartype cpu: Union [float, integer]
-    :ivar memory: memory
-    :vartype memory: integer
-
-    :param cpu: cpu
-    :type cpu: Union [float, integer]
-    :param memory: memory
-    :type memory: integer
-    """
-
-    def __init__(self, cpu, memory):
-        self.validate(cpu, memory)
-        super(ObjDict, self).__init__(cpu=cpu, memory=memory)
-
-    @staticmethod
-    def validate(cpu, memory):
-        if (not isinstance(cpu, float) and not isinstance(cpu, six.integer_types)) or cpu <= 0:
-            raise InvalidParameterException('cpu must be a positive float or integer')
-        if not isinstance(memory, six.integer_types) or memory <= 0:
-            raise InvalidParameterException('memory must be a positive integer')
-
-
-class RoutedNetworkLimits(object):
-    """
-    RoutedNetworkLimits may be one of: \n
-    RoutedNetworkLimits.SMALL (cpu: 1core, memory: 4GB) \n
-    RoutedNetworkLimits.MEDIUM (cpu: 2cores, memory: 8GB) \n
-    RoutedNetworkLimits.LARGE (cpu: 4cores, memory: 16GB) \n
-    """
-    SMALL = _Limits(1, 4096)
-    MEDIUM = _Limits(2, 8192)
-    LARGE = _Limits(4, 16384)

--- a/rapyuta_io/rio_client.py
+++ b/rapyuta_io/rio_client.py
@@ -1629,7 +1629,6 @@ class Client(object):
         if not isinstance(native_network, NativeNetwork):
             raise InvalidParameterException("native_network must be non-empty and of type "
                                             "rapyuta_io.clients.native_network.NativeNetwork")
-
         native_network_response = self._catalog_client.create_native_network(native_network)
         return self.get_native_network(native_network_response['guid'])
 

--- a/sdk_test/package/native_network_tests.py
+++ b/sdk_test/package/native_network_tests.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 from rapyuta_io import DeploymentStatusConstants, DeviceArch
 from rapyuta_io.clients.deployment import DeploymentPhaseConstants
-from rapyuta_io.clients.native_network import NativeNetwork, NativeNetworkLimits, Parameters
+from rapyuta_io.clients.native_network import NativeNetwork, Parameters
+from rapyuta_io.clients.common_models import Limits
 from rapyuta_io.clients.package import Runtime, ROSDistro
 from rapyuta_io.utils.utils import generate_random_value
 from sdk_test.config import Configuration
@@ -36,7 +37,7 @@ class NativeNetworkTest(PackageTest, DeviceTest):
         self.name = 'net-' + generate_random_value()
         self.ros_distro = ROSDistro.MELODIC
         self.runtime = Runtime.CLOUD
-        self.parameters = Parameters(NativeNetworkLimits.SMALL)
+        self.parameters = Parameters(Limits(cpu=1, memory=1024))
         self.device_runtime = Runtime.DEVICE
         self.docker_device = self.config.get_devices(arch=DeviceArch.AMD64, runtime='Dockercompose')[0]
         self.docker_device.refresh()

--- a/sdk_test/package/routed_networks_tests.py
+++ b/sdk_test/package/routed_networks_tests.py
@@ -7,8 +7,8 @@ from sdk_test.config import Configuration
 from sdk_test.device.device_test import DeviceTest
 from sdk_test.package.package_test import PackageTest
 from sdk_test.util import get_logger, add_package, delete_package, get_package
-from rapyuta_io.clients.routed_network import Parameters, RoutedNetworkLimits
-
+from rapyuta_io.clients.routed_network import Parameters
+from rapyuta_io.clients.common_models import Limits
 
 class RoutedNetworkTest(PackageTest, DeviceTest):
 
@@ -33,7 +33,7 @@ class RoutedNetworkTest(PackageTest, DeviceTest):
         self.routed_network = None
         self.docker_device = self.config.get_devices(arch=DeviceArch.AMD64, runtime='Dockercompose')[0]
         self.supervisor_device = self.config.get_devices(arch=DeviceArch.AMD64, runtime='Preinstalled')[0]
-        self.parameters = Parameters(RoutedNetworkLimits.SMALL)
+        self.parameters = Parameters(Limits(cpu=0.5, memory=1024))
 
     def create_routed_network(self, runtime, parameters):
         if runtime == Runtime.CLOUD:
@@ -125,7 +125,7 @@ class RoutedNetworkTest(PackageTest, DeviceTest):
 
     def test_create_cloud_routed_network_with_parameters(self):
         self.logger.info('Started creating cloud routed network with parameters')
-        self.create_routed_network(Runtime.CLOUD, Parameters(RoutedNetworkLimits.SMALL))
+        self.create_routed_network(Runtime.CLOUD, Parameters(Limits(cpu=0.5, memory=1024)))
         routed_network = self.config.client.get_routed_network(self.routed_network.guid)
         self.assertEqual(self.routed_network.runtime, 'cloud')
         self.assertEqual(routed_network.guid, self.routed_network.guid)

--- a/tests/native_network_test.py
+++ b/tests/native_network_test.py
@@ -7,10 +7,10 @@ from rapyuta_io.utils import ResourceNotFoundError
 from rapyuta_io.utils.error import InvalidParameterException
 from tests.utils.client import get_client, headers, add_auth_token
 from rapyuta_io.clients.package import Runtime, ROSDistro, Device
-from rapyuta_io.clients.native_network import NativeNetwork, Parameters, NativeNetworkLimits
+from rapyuta_io.clients.native_network import NativeNetwork, Parameters
 from tests.utils.native_network_responses import NATIVE_NETWORK_CREATE_SUCCESS, NATIVE_NETWORK_LIST_SUCCESS, \
     NATIVE_NETWORK_GET_SUCCESS, NATIVE_NETWORK_FAILURE, NATIVE_NETWORK_NOT_FOUND
-
+from rapyuta_io.clients.common_models import Limits
 
 class NativeNetworkTests(unittest.TestCase):
     def setUp(self):
@@ -76,14 +76,6 @@ class NativeNetworkTests(unittest.TestCase):
         with self.assertRaises(InvalidParameterException) as e:
             client.create_native_network(NativeNetwork('native_network_name', Runtime.CLOUD, ROSDistro.MELODIC,
                                                        'invalid_parameters'))
-        self.assertEqual(str(e.exception), expected_err_msg)
-
-    def test_create_native_network_parameters_invalid_limits(self):
-        expected_err_msg = 'limits must be one of rapyuta_io.clients.native_network.NativeNetworkLimits'
-        client = get_client()
-        with self.assertRaises(InvalidParameterException) as e:
-            client.create_native_network(
-                NativeNetwork('native_network_name', Runtime.CLOUD, ROSDistro.MELODIC, Parameters("")))
         self.assertEqual(str(e.exception), expected_err_msg)
 
     def test_create_native_network_device_runtime_parameters_invalid_device(self):
@@ -191,8 +183,7 @@ class NativeNetworkTests(unittest.TestCase):
         expected_payload = {
             "name": "native_network_name",
             "runtime": 'cloud',
-            "rosDistro": 'noetic',
-            "parameters": {"limits": {"cpu": 1, "memory": 4096}}
+            "rosDistro": 'noetic'
         }
         expected_url = 'https://gacatalog.apps.okd4v2.prod.rapyuta.io/nativenetwork'
         mock_create_native_network = Mock()
@@ -204,10 +195,11 @@ class NativeNetworkTests(unittest.TestCase):
         mock_request.side_effect = [mock_create_native_network, mock_get_native_network]
 
         client = get_client()
-        native_network_parameters = Parameters(NativeNetworkLimits.SMALL)
+        native_network_parameters = None
         native_network_payload = NativeNetwork("native_network_name", Runtime.CLOUD, ROSDistro.NOETIC,
                                                native_network_parameters)
         native_network_response = client.create_native_network(native_network_payload)
+        print(headers, expected_payload, expected_url, 'POST', None)
         mock_request.assert_has_calls([
             call(headers=headers, json=expected_payload, url=expected_url, method='POST', params=None),
             call(headers=headers, json=None, url=expected_url + '/' + 'net-guid', method='GET', params=None)
@@ -222,7 +214,7 @@ class NativeNetworkTests(unittest.TestCase):
             "name": "native_network_name",
             "runtime": 'cloud',
             "rosDistro": 'kinetic',
-            "parameters": {"limits": {"cpu": 1, "memory": 4096}}
+            "parameters": {"limits": {"cpu": 1, "memory": 1024}}
         }
         expected_url = 'https://gacatalog.apps.okd4v2.prod.rapyuta.io/nativenetwork'
         mock_create_native_network = Mock()
@@ -234,7 +226,7 @@ class NativeNetworkTests(unittest.TestCase):
         mock_request.side_effect = [mock_create_native_network, mock_get_native_network]
 
         client = get_client()
-        native_network_parameters = Parameters(NativeNetworkLimits.SMALL)
+        native_network_parameters = Parameters(limits=Limits(1,1024))
         native_network_payload = NativeNetwork("native_network_name", Runtime.CLOUD, ROSDistro.KINETIC,
                                                native_network_parameters)
         native_network_response = client.create_native_network(native_network_payload)


### PR DESCRIPTION
### Description
Context: rapyuta.io backend already supports custom `cpu` and `memory` values for cloud networks. You can specify cpu in multiples of 0.025 cores and memory in multiples of 128MiB. Added a change in cli where cloud network can be created using custom CPU cores and memory.

To support this private _Limits from NativeNetwork and Routed Network was bring to common models that can be exposed to CLI directly.

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1087900686)
