### PR TITLE
chore: runs workflows only on `push`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,5 +1,5 @@
 name: Code Quality
-on: [push, pull_request]
+on: [ push ]
 
 jobs:
   checks:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Release
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   release:


### PR DESCRIPTION
### Description

This PR optimizes existing workflows.

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1092132524)
