### PR TITLE
[SDK] feat(rip): adds support for token_level in get_auth_token

### DIFF
--- a/rapyuta_io/clients/rip_client.py
+++ b/rapyuta_io/clients/rip_client.py
@@ -1,7 +1,19 @@
 from __future__ import absolute_import
+
+import enum
+
 from rapyuta_io.utils import RestClient
 from rapyuta_io.utils.rest_client import HttpMethod
 from rapyuta_io.utils.utils import get_api_response_data
+
+
+class AuthTokenLevel(str, enum.Enum):
+    def __str__(self):
+        return str(self.value)
+
+    LOW = "low"
+    MED = "med"
+    HIGH = "high"
 
 
 class RIPClient:
@@ -10,9 +22,18 @@ class RIPClient:
     def __init__(self, rip_host):
         self._rip_host = rip_host
 
-    def get_auth_token(self, email, password):
+    def get_auth_token(self, email, password, token_level=AuthTokenLevel.LOW):
+        """
+        Fetches an auth token.
+
+        You can fetch a new auth token and also specify the token validity
+        with the token_level argument. It takes one of the following values
+        `low`, `med` and `high` which correspond to 24h, 7d and 90d of token
+        validity respectively.
+        """
         url = self._rip_host + self.AUTH_TOKEN_PATH
         payload = {'email': email, 'password': password}
-        response = RestClient(url).method(HttpMethod.POST).query_param({'type': 'high'}).execute(payload)
+        response = RestClient(url).method(HttpMethod.POST).query_param(
+            {'type': token_level}).execute(payload)
         data = get_api_response_data(response, parse_full=True)
         return data['data']['token']

--- a/rapyuta_io/rio_client.py
+++ b/rapyuta_io/rio_client.py
@@ -12,7 +12,8 @@ from rapyuta_io.clients.catalog_client import CatalogClient
 from rapyuta_io.clients.core_api_client import CoreAPIClient
 from rapyuta_io.clients.deployment import Deployment
 from rapyuta_io.clients.device import Device
-from rapyuta_io.clients.metrics import QueryMetricsRequest, MetricOperation, MetricFunction, QueryMetricsResponse, \
+from rapyuta_io.clients.metrics import QueryMetricsRequest, MetricOperation, \
+    MetricFunction, QueryMetricsResponse, \
     ListMetricsRequest, ListTagKeysRequest, \
     Metric, Tags, ListTagValuesRequest
 from rapyuta_io.clients.native_network import NativeNetwork
@@ -20,11 +21,13 @@ from rapyuta_io.clients.package import Package
 from rapyuta_io.clients.package import Runtime, ROSDistro, RestartPolicy
 from rapyuta_io.clients.persistent_volumes import VolumeInstance
 from rapyuta_io.clients.project import Project
-from rapyuta_io.clients.rip_client import RIPClient
-from rapyuta_io.clients.rosbag import ROSBagJob, ROSBagJobStatus, ROSBagBlob, ROSBagBlobStatus
+from rapyuta_io.clients.rip_client import RIPClient, AuthTokenLevel
+from rapyuta_io.clients.rosbag import ROSBagJob, ROSBagJobStatus, ROSBagBlob, \
+    ROSBagBlobStatus
 from rapyuta_io.clients.routed_network import RoutedNetwork, Parameters
 from rapyuta_io.clients.secret import Secret
-from rapyuta_io.utils import InvalidAuthTokenException, InvalidParameterException
+from rapyuta_io.utils import InvalidAuthTokenException, \
+    InvalidParameterException
 from rapyuta_io.utils import to_objdict
 from rapyuta_io.utils.settings import VOLUME_PACKAGE_ID, default_host_config
 from rapyuta_io.utils.utils import get_api_response_data, valid_list_elements
@@ -78,7 +81,7 @@ class Client(object):
         setattr(obj, '_project', self._catalog_client._project)
 
     @staticmethod
-    def get_auth_token(email, password):
+    def get_auth_token(email, password, token_level=AuthTokenLevel.LOW):
         """
         Generate and fetch a new API Authentication Token.
 
@@ -86,16 +89,19 @@ class Client(object):
         :type email: str
         :param password: User password for the account.
         :type password: str
+        :param token_level: Level of the token. This corresponds to token validity
+        :type token_level: AuthTokenLevel
         :return: str
 
         Following example demonstrates how to get auth token
 
             >>> from rapyuta_io import Client
-            >>> auth_token = Client.get_auth_token('email@example.com', 'password')
+            >>> from rapyuta_io.clients.rip_client import AuthTokenLevel
+            >>> auth_token = Client.get_auth_token('email@example.com', 'password', AuthTokenLevel.MED)
             >>> client = Client(auth_token, 'project-id')
         """
         rip_client = RIPClient(rip_host=Client._get_api_endpoints('rip_host'))
-        return rip_client.get_auth_token(email, password)
+        return rip_client.get_auth_token(email, password, token_level)
 
     def set_project(self, project_guid):
         """


### PR DESCRIPTION
### Description
This commit adds support for specifying `token_level` while generating a new auth token. A rapyuta.io token has three levels, i.e. low, med and high that correspond to 24h, 7d and 90d token validity, respectively.

Usage example:

```python
>>> from rapyuta_io import Client
>>> from rapyuta_io.clients.rip_client import AuthTokenLevel
>>> auth_token = Client.get_auth_token('email@example.com', 'password', AuthTokenLevel.MED)
>>> client = Client(auth_token, 'project-id')
```

Used by https://github.com/rapyuta-robotics/rapyuta-io-cli/pull/154



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1100429816)
