### PR TITLE
fix(sdk-tests): sends `organization_guid` in create project request

### DIFF
--- a/sdk_test/config.json.example
+++ b/sdk_test/config.json.example
@@ -5,6 +5,7 @@
   "hwil_user": "USER",
   "hwil_password": "PASSWORD",
   "auth_token": "Bearer AUTH_TOKEN",
+  "organization_guid": "org_guid",
   "devices": [
     {
       "name":  "NAME",

--- a/sdk_test/config.py
+++ b/sdk_test/config.py
@@ -1,12 +1,16 @@
 from __future__ import absolute_import
+
 import json
 import os
 
-from rapyuta_io import Client, SecretConfigSourceSSHAuth, SecretConfigDocker, DeviceArch, Secret, Project
-from rapyuta_io.utils.utils import create_auth_header, prepend_bearer_to_auth_token, generate_random_value
-from rapyuta_io.utils.error import InvalidParameterException
-from six.moves import filter
 import six
+from six.moves import filter
+
+from rapyuta_io import Client, SecretConfigSourceSSHAuth, SecretConfigDocker, \
+    DeviceArch, Secret, Project
+from rapyuta_io.utils.error import InvalidParameterException
+from rapyuta_io.utils.utils import create_auth_header, \
+    prepend_bearer_to_auth_token, generate_random_value
 
 
 class _Singleton(type):
@@ -14,7 +18,8 @@ class _Singleton(type):
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(_Singleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super(_Singleton, cls).__call__(*args,
+                                                                  **kwargs)
         return cls._instances[cls]
 
 
@@ -47,6 +52,7 @@ class Configuration(six.with_metaclass(_Singleton, object)):
             "hwil_user": "user",
             "hwil_password": "password",
             "auth_token": "<AUTH>",
+            "organization_guid": "<org_guid>",
             "devices": [
                 {
                     "name": "DEVICE_NAME",
@@ -85,6 +91,7 @@ class Configuration(six.with_metaclass(_Singleton, object)):
         if not isinstance(self.test_files, list):
             raise InvalidParameterException('test_files must be a list of test file names')
         self.worker_threads = self._config['worker_threads']
+        self.organization_guid = self._config.get('organization_guid')
 
     def validate(self):
         # if len(self.get_device_configs(arch=DeviceArch.AMD64, runtime='Preinstalled')) != 1:
@@ -105,7 +112,8 @@ class Configuration(six.with_metaclass(_Singleton, object)):
     def create_project(self):
         # Project name needs to be between 3 and 15 Characters
         name = 'test-{}'.format(generate_random_value(8))
-        self._project = self.client.create_project(Project(name))
+        self._project = self.client.create_project(
+            Project(name, organization_guid=self.organization_guid))
         self.set_project(self._project.guid)
 
     def delete_project(self):

--- a/sdk_test/coreapi/project_test.py
+++ b/sdk_test/coreapi/project_test.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 import unittest
 
 from rapyuta_io import Client, Project, Secret, SecretConfigSourceSSHAuth
@@ -18,7 +19,11 @@ class TestProject(unittest.TestCase):
             self.config.client.delete_project(self.project.guid)
 
     def test_create_project(self):
-        self.project = self.config.client.create_project(Project('test-{}'.format(generate_random_value(5))))
+        p = Project(
+            'test-{}'.format(generate_random_value(5)),
+            organization_guid=self.config.organization_guid
+        )
+        self.project = self.config.client.create_project(p)
         self.assertIsInstance(self.project, Project)
         self.assertIsNotNone(self.project.guid)
         self.assertIsNotNone(self.project.creator)
@@ -26,7 +31,11 @@ class TestProject(unittest.TestCase):
         self.assertIsNotNone(self.project.users)
 
     def test_list_project(self):
-        self.project = self.config.client.create_project(Project('test-{}'.format(generate_random_value(5))))
+        p = Project(
+            'test-{}'.format(generate_random_value(5)),
+            organization_guid=self.config.organization_guid
+        )
+        self.project = self.config.client.create_project(p)
         project_list = self.config.client.list_projects()
         project_list = [p for p in project_list if p.guid == self.project.guid]
         self.assertEqual(len(project_list), 1)
@@ -34,6 +43,9 @@ class TestProject(unittest.TestCase):
     def test_client_without_project(self):
         auth = self.config.get_auth_token()
         client = Client(auth)
-        self.assertRaises(BadRequestError,
-                          lambda: client.create_secret(Secret('test-secret',
-                                                              SecretConfigSourceSSHAuth('test'))))
+        self.assertRaises(
+            BadRequestError,
+            lambda: client.create_secret(
+                Secret('test-secret', SecretConfigSourceSSHAuth('test'))
+            )
+        )


### PR DESCRIPTION
### Issue
![image](https://github.com/rapyuta-robotics/rapyuta-io-sdk/assets/5305744/b32b21e2-24ff-453d-abee-c97ae39cec2f)

### Fix
We are now explicitly passing the `organization_guid` while creating a project instance in the SDK tests.

This will also require the integration test to update the `config.json`.

### Testing


```bash
Creating a virtualenv for this project...
Pipfile: /src/Pipfile
Using /usr/local/bin/python3 (3.10.11) to create virtualenv...
created virtual environment CPython3.10.11.final.0-64 in 520ms
  creator CPython3Posix(dest=/root/.local/share/virtualenvs/src-NVTF7jWz, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/root/.local/share/virtualenv)
    added seed packages: pip==23.1.2, setuptools==67.7.2, wheel==0.40.0
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

✔ Successfully created virtual environment!
Virtualenv location: /root/.local/share/virtualenvs/src-NVTF7jWz
Installing dependencies from Pipfile.lock (91867b)...
Installing dependencies from Pipfile.lock (91867b)...
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Collecting coverage
  Using cached coverage-7.2.5-cp310-cp310-musllinux_1_1_x86_64.whl (233 kB)
Installing collected packages: coverage
Successfully installed coverage-7.2.5
2023-05-15 06:36:45,999 - RIO_SDK Logger - INFO - Creating project
2023-05-15 06:36:46,239 - RIO_SDK Logger - INFO - Creating secrets
2023-05-15 06:37:06,718 - RIO_SDK Logger - INFO - On-boarding the device: sdktestpre
2023-05-15 06:37:06,718 - RIO_SDK Logger - DEBUG - Adding the device on the platform
2023-05-15 06:37:09,210 - RIO_SDK Logger - DEBUG - Running the onboarding command
2023-05-15 06:37:10,308 - RIO_SDK Logger - DEBUG - Submitted the command successfully!
2023-05-15 06:37:10,309 - RIO_SDK Logger - DEBUG - Waiting for the command status...
2023-05-15 06:38:11,141 - RIO_SDK Logger - INFO - On-boarding the device: sdktestdocker
2023-05-15 06:38:11,141 - RIO_SDK Logger - DEBUG - Adding the device on the platform
2023-05-15 06:38:12,661 - RIO_SDK Logger - DEBUG - Running the onboarding command
2023-05-15 06:38:13,754 - RIO_SDK Logger - DEBUG - Submitted the command successfully!
2023-05-15 06:38:13,754 - RIO_SDK Logger - DEBUG - Waiting for the command status...
2023-05-15 06:40:15,063 - RIO_SDK Logger - INFO - Waiting for devices to come online
2023-05-15 06:43:36,488 - RIO_SDK Logger - INFO - All devices came online
2023-05-15 06:43:36,490 - RIO_SDK Logger - INFO - subscribing to metrics
2023-05-15 06:43:36,593 - RIO_SDK Logger - INFO - Command script output.txt is going to execute on device sdktestdocker(f7498211-efe3-4cac-9532-566e5ecabe8b)
2023-05-15 06:43:36,868 - RIO_SDK Logger - INFO - Creating the package: test-deployment-talker-docker-pkg
2023-05-15 06:43:37,119 - RIO_SDK Logger - INFO - waiting for 120 seconds
2023-05-15 06:43:37,655 - RIO_SDK Logger - INFO - Creating the package: test-native-network-talker-cloud-pkg
2023-05-15 06:43:37,816 - RIO_SDK Logger - INFO - Command executed successfully. Result: Script started, file is output.txt# Script done, file is output.txt
2023-05-15 06:43:37,817 - RIO_SDK Logger - INFO - Command pwd is going to execute on device sdktestdocker(f7498211-efe3-4cac-9532-566e5ecabe8b)
2023-05-15 06:43:37,947 - RIO_SDK Logger - INFO - creating a device with dockercompose runtime
2023-05-15 06:43:38,257 - RIO_SDK Logger - DEBUG - Waiting for the Package (and its Builds) to finish...
2023-05-15 06:43:38,345 - RIO_SDK Logger - DEBUG - Waiting for the Package (and its Builds) to finish...
2023-05-15 06:43:38,922 - RIO_SDK Logger - INFO - Command executed successfully. Result: /home
2023-05-15 06:43:38,922 - RIO_SDK Logger - INFO - Adding new label
2023-05-15 06:43:39,503 - RIO_SDK Logger - INFO - Validating label key and value
2023-05-15 06:43:39,609 - RIO_SDK Logger - INFO - Checking labels count after adding new label: dhcbk
2023-05-15 06:43:39,711 - RIO_SDK Logger - INFO - Label added successfully
2023-05-15 06:43:39,711 - RIO_SDK Logger - INFO - Adding the same label
2023-05-15 06:43:40,161 - RIO_SDK Logger - INFO - ConflictError Exception raised while Adding the same label
2023-05-15 06:43:40,249 - RIO_SDK Logger - INFO - Deleting label
2023-05-15 06:43:40,905 - RIO_SDK Logger - INFO - validating the config variables of the created device
2023-05-15 06:43:40,905 - RIO_SDK Logger - INFO - deleting the device
2023-05-15 06:43:41,085 - RIO_SDK Logger - INFO - Checking labels count 0 == 1
2023-05-15 06:43:41,085 - RIO_SDK Logger - INFO - Label deleted (key: vrhiz)
2023-05-15 06:43:41,179 - RIO_SDK Logger - INFO - creating a device with dockercompose runtime
2023-05-15 06:43:41,231 - RIO_SDK Logger - INFO - Total device labels: 0
2023-05-15 06:43:41,232 - RIO_SDK Logger - INFO - []
2023-05-15 06:43:41,232 - RIO_SDK Logger - INFO - Updating invalid device label
2023-05-15 06:43:41,800 - RIO_SDK Logger - INFO - LabelNotFoundException Exception raised while Updating invalid device label
2023-05-15 06:43:41,800 - RIO_SDK Logger - INFO - Updating label
2023-05-15 06:43:42,894 - RIO_SDK Logger - INFO - Checking updated label: vrhiz
2023-05-15 06:43:42,894 - RIO_SDK Logger - INFO - Validating label key and value
2023-05-15 06:43:42,995 - RIO_SDK Logger - INFO - Label updated successfully
2023-05-15 06:43:44,019 - RIO_SDK Logger - INFO - Started creating build
2023-05-15 06:43:44,269 - RIO_SDK Logger - INFO - validating the config variables of the created device
2023-05-15 06:43:44,269 - RIO_SDK Logger - INFO - deleting the device
2023-05-15 06:43:44,619 - RIO_SDK Logger - INFO - creating a device with preinstalled runtime
2023-05-15 06:43:45,584 - RIO_SDK Logger - INFO - validating the config variables of the created device
2023-05-15 06:43:45,584 - RIO_SDK Logger - INFO - deleting the device
2023-05-15 06:43:46,026 - RIO_SDK Logger - INFO - creating a python3 device with both the runtimes enabled runtime
2023-05-15 06:43:46,914 - RIO_SDK Logger - INFO - validating the config variables of the created device
2023-05-15 06:43:46,914 - RIO_SDK Logger - INFO - deleting the device
2023-05-15 06:43:47,150 - RIO_SDK Logger - INFO - creating a device with python3 preinstalled runtime
2023-05-15 06:43:47,858 - RIO_SDK Logger - INFO - validating the config variables of the created device
2023-05-15 06:43:47,858 - RIO_SDK Logger - INFO - deleting the device
2023-05-15 06:43:48,069 - RIO_SDK Logger - INFO - creating a device with python3 preinstalled runtime v2
2023-05-15 06:43:49,007 - RIO_SDK Logger - INFO - validating the config variables of the created device
2023-05-15 06:43:49,007 - RIO_SDK Logger - INFO - deleting the device
2023-05-15 06:43:49,221 - RIO_SDK Logger - INFO - creating a device
2023-05-15 06:43:50,310 - RIO_SDK Logger - INFO - deleting the device
2023-05-15 06:43:50,536 - RIO_SDK Logger - INFO - creating a device
2023-05-15 06:43:53,675 - RIO_SDK Logger - INFO - deleting the device
2023-05-15 06:43:53,971 - RIO_SDK Logger - INFO - creating a device
2023-05-15 06:43:54,998 - RIO_SDK Logger - INFO - deleting the device
2023-05-15 06:43:55,201 - RIO_SDK Logger - INFO - creating a device on python2 with dockercompose runtime
2023-05-15 06:43:56,265 - RIO_SDK Logger - INFO - validating the config variables of the created device
2023-05-15 06:43:57,257 - RIO_SDK Logger - INFO - deleting the device
2023-05-15 06:44:01,385 - RIO_SDK Logger - INFO - Creating the build: pingpong-build
2023-05-15 06:44:01,836 - RIO_SDK Logger - DEBUG - Waiting for the build pingpong-build to complete
2023-05-15 06:45:37,964 - RIO_SDK Logger - INFO - Started add device configuration variables test case
2023-05-15 06:45:38,069 - RIO_SDK Logger - INFO - Total device configuration variables: 4
```



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1116296047)
