### PR TITLE
fix(paramserver): raise exception during download when trees not found

### DIFF
--- a/rapyuta_io/clients/paramserver.py
+++ b/rapyuta_io/clients/paramserver.py
@@ -11,7 +11,7 @@ import os
 import hashlib
 import mimetypes
 
-from rapyuta_io.utils import RestClient, InvalidParameterException
+from rapyuta_io.utils import RestClient, InvalidParameterException, ConfigNotFoundException
 from rapyuta_io.utils.rest_client import HttpMethod
 from rapyuta_io.utils.settings import PARAMSERVER_API_TREE_PATH, PARAMSERVER_API_TREEBLOBS_PATH, PARAMSERVER_API_FILENODE_PATH
 from rapyuta_io.utils.utils import create_auth_header, prepend_bearer_to_auth_token, get_api_response_data, \
@@ -277,6 +277,9 @@ class _ParamserverClient:
 
         if tree_names:
             api_tree_names = [tree_name for tree_name in api_tree_names if tree_name in tree_names]
+
+        if not api_tree_names:
+            raise ConfigNotFoundException('One or more trees not found')
 
         blob_temp_dir = tempfile.mkdtemp()
 

--- a/rapyuta_io/rio_client.py
+++ b/rapyuta_io/rio_client.py
@@ -643,16 +643,18 @@ class Client(object):
         Following example demonstrates how to use download_configurations and handle errors.
 
             >>> from rapyuta_io import Client
-            >>> from rapyuta_io.utils.error import APIError, InternalServerError
+            >>> from rapyuta_io.utils.error import APIError, InternalServerError, ConfigNotFoundException
             >>> client = Client(auth_token='auth_token', project='project_guid')
             >>> try:
             ...     client.download_configurations('path/to/destination_dir',
             ...                                    tree_names=['config_tree1', 'config_tree2'],
             ...                                    delete_existing_trees=True)
             ... except (APIError, InternalServerError) as e:
-            ...     print 'failed API request', e.tree_path, e
+            ...     print('failed API request', e.tree_path, e)
+                except ConfigNotFoundException as e:
+                    print ('config not found')
             ... except (IOError, OSError) as e:
-            ...     print 'failed file/directory creation', e
+            ...     print('failed file/directory creation', e)
 
         """
         return self._paramserver_client.download_configurations(rootdir, tree_names, delete_existing_trees)


### PR DESCRIPTION
### Description
When no matching tree names are found in download_configurations, the code will now raise a ConfigNotFoundException. This will assure that clients get a proper error instead of not knowing what happened.

Wrike Ticket: https://www.wrike.com/open.htm?id=1182864968