### PR TITLE
fix: use explicit --python in matrix CI to ensure correct Python version

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,7 +18,15 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install Dependencies
-        run: uv sync --dev
+        run: uv sync --python ${{ matrix.python-version }} --dev
+
+      - name: Smoke import
+        run: |
+          uv run --python ${{ matrix.python-version }} python -c "
+          import rapyuta_io
+          from rapyuta_io import RIOClient
+          print('smoke imports OK')
+          "
 
       - name: Unit Tests
-        run: uv run pytest --cov=rapyuta_io tests/
+        run: uv run --python ${{ matrix.python-version }} pytest --cov=rapyuta_io tests/

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           uv run --python ${{ matrix.python-version }} python -c "
           import rapyuta_io
-          from rapyuta_io import RIOClient
+          from rapyuta_io import Client
           print('smoke imports OK')
           "
 


### PR DESCRIPTION
## Summary

- \`uv sync\`/\`uv run\` without \`--python\` ignores the matrix entry and falls back to the system default Python, causing all matrix jobs to silently run on the same version
- Adds \`--python \${{ matrix.python-version }}\` to both \`uv sync\` and \`uv run\` so each matrix job actually tests the declared Python version
- Adds smoke imports step before running the test suite

## Test plan

- [ ] Verify all 4 matrix jobs (3.10, 3.11, 3.12, 3.13) run on their declared Python version
- [ ] Smoke imports pass on each matrix version
- [ ] Unit tests pass on each matrix version

🤖 Generated with [Claude Code](https://claude.com/claude-code)